### PR TITLE
fix: default alpha value

### DIFF
--- a/time-splatting/dataloader.py
+++ b/time-splatting/dataloader.py
@@ -132,7 +132,7 @@ class TimeLapseDataset:
         if image.shape[2] == 4:  # check if image has alpha channel
             alpha = image[..., 3:4]
         else:
-            alpha = np.ones((image.shape[0], image.shape[1], 1), dtype=image.dtype)
+            alpha = 255 * np.ones((image.shape[0], image.shape[1], 1), dtype=image.dtype)
         image = image[..., :3]  # remove alpha channel if present
 
         time = self.dates[index]


### PR DESCRIPTION
Fixing default alpha value from 1 to 255.
The training was stuck at its initial loss, around 0.4, with no-alpha png/jpeg images.